### PR TITLE
Add Cosmic Connector Example Implementation with Bazel Support

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,19 @@
+# Copyright 2024 Outernet Council Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@gazelle//:def.bzl", "gazelle")
+
+# gazelle:prefix github.com/outernetcouncil/federation
+gazelle(name = "gazelle")
+

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,14 +65,20 @@ go_deps.module(
     sum = "h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=",
     version = "v0.8.0",
 )
+go_deps.module(
+    path = "github.com/google/go-cmp",
+    sum = "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=",
+    version = "v0.6.0",
+)
 
 use_repo(
     go_deps,
-    "org_golang_google_genproto",
-    "org_golang_google_protobuf",
+    "com_github_google_go_cmp",
     "com_github_mattn_go_colorable",
     "com_github_mattn_go_isatty",
     "com_github_rs_zerolog",
+    "org_golang_google_genproto",
     "org_golang_google_grpc",
+    "org_golang_google_protobuf",
     "org_golang_x_sync",
 )

--- a/examples/golang/cosmicconnector/BUILD.bazel
+++ b/examples/golang/cosmicconnector/BUILD.bazel
@@ -1,0 +1,37 @@
+# Copyright 2024 Outernet Council Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_binary(
+    name = "cosmic_connector",
+    embed = [":cosmicconnector_lib"],
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "cosmicconnector_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/outernetcouncil/federation/examples/golang/cosmicconnector/example",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//examples/golang/cosmicconnector/config",
+        "//examples/golang/cosmicconnector/handler",
+        "//pkg/go/cosmicconnector",
+        "//pkg/go/server",
+        "@com_github_rs_zerolog//:zerolog",
+    ],
+)

--- a/examples/golang/cosmicconnector/README.md
+++ b/examples/golang/cosmicconnector/README.md
@@ -1,0 +1,207 @@
+## Cosmic Connector Example Implementation
+
+This example showcases a basic setup of the Cosmic Connector, a Federation server implementation allowing for custom handlers per Federation RPC. The example demonstrates configuration, server setup, and interaction with gRPC services.
+
+## Sample Configuration
+
+The Cosmic Connector is configured using a [ConnectorParams](../../pkg/go/config/config.proto) message defined in Protocol Buffers. Below is an example of a configuration in text protobuf format:
+
+```textproto
+port: 50052
+observability_params {
+  channelz_address: "0.0.0.0:50051"
+  pprof_address: "0.0.0.0:6060"
+}
+```
+
+### Configuration Breakdown
+
+- **Transport Security**:
+  - `insecure: {}`: Indicates that the connector will communicate over plain-text HTTP/2. For secure deployments, consider using TLS by configuring `system_cert_pool` instead.
+  - For more details, refer to [config/config.proto](../../pkg/go/config/config.proto).
+
+- **Provider Endpoint URI**:
+  - `provider_endpoint_uri`: Specifies the RESTful provider endpoint that the Cosmic Connector bridges.
+
+- **Authentication Strategy**:
+  - `auth_strategy { none: {} }`: Sets the authentication strategy to none. For secure communication, refer to the [serverauth](../../pkg/go/auth/serverauth.go) package to implement JWT-based authentication.
+
+- **Observability Parameters**:
+  - `channelz_address`: Address for the gRPC Channelz introspection service.
+  - `pprof_address`: Address for the pprof HTTP server for profiling.
+
+For detailed configuration options, see [config/config.proto](config/config.proto).
+
+## Running the Example
+
+The example can be built and run using Bazel.
+
+### Prerequisites
+
+- **Bazelisk**: We recommend using Bazelisk (the Bazel wrapper) instead of installing Bazel directly:
+  - Installation guide: https://github.com/bazelbuild/bazelisk#installation
+  - Bazelisk automatically downloads and uses the correct Bazel version
+  - Current project recommends Bazel 7.4.0 or later
+- **Dependencies**: All dependencies are managed through Bazel's MODULE.bazel file.
+  - github.com/rs/zerolog - Logging
+  - google.golang.org/grpc - gRPC functionality
+  - google.golang.org/protobuf - Protocol Buffers support
+
+### Building the Example
+
+Build the example using Bazel:
+
+```bash
+bazel build //examples/golang/cosmicconnector:cosmic_connector
+```
+
+### Running the Example
+
+Execute the built binary with the necessary flags:
+
+```bash
+bazel run //examples/golang/cosmicconnector:cosmic_connector -- \
+  -config path/to/config.textproto \
+  -log-level info
+```
+
+#### Flags:
+
+- `-config`: Path to the text protobuf configuration file (e.g., `config.textproto`). Required.
+- `-log-level`: Sets the logging level (options: `disabled`, `warn`, `panic`, `info` (default), `fatal`, `error`, `debug`, `trace`).
+- `-dry-run`: (Optional) Validate the configuration without starting the server. Exits with a non-zero return code if the config is invalid.
+
+**Example: Dry Run Configuration Validation**
+
+```bash
+bazel run //examples/golang/cosmicconnector:cosmic_connector -- \
+  -config path/to/config.textproto -dry-run
+```
+
+For more details, refer to the [main.go](./main.go) source file.
+
+## Sample gRPC Calls
+
+Once the Cosmic Connector is running, you can interact with its gRPC services using `grpcurl`. Below are sample commands for various operations.
+
+### ListServiceOptions
+
+Retrieve service options based on specific filters.
+
+```bash
+grpcurl -plaintext -d '{
+  "service_attributes_filters": {
+    "bidirectional_service_attributes_filter": {
+      "bandwidth_bps_minimum": 1000000,
+      "one_way_latency_maximum": "100ms"
+    }
+  }
+}' localhost:50052 outernet.federation.v1alpha.Federation/ListServiceOptions
+```
+
+*Refer to [grpc_server.go](../../pkg/go/server/grpc_server.go) and [handler.go](./handler/handler.go) for implementation details.*
+
+### ScheduleService
+
+Schedule a new service with specified parameters.
+
+```bash
+grpcurl -plaintext -d '{
+  "requestor_edge_to_requestor_edge": {
+    "x_interconnection_points": [{
+      "uuid": "point1",
+      "coordinates": {
+        "entry": [{
+          "interval": {
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-02T00:00:00Z"
+          },
+          "geodetic_wgs84": {
+            "longitude_deg": 0,
+            "latitude_deg": 0,
+            "height_wgs84_m": 0
+          }
+        }]
+      }
+    }],
+    "y_interconnection_points": [{
+      "uuid": "point2",
+      "coordinates": {
+        "entry": [{
+          "interval": {
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-02T00:00:00Z"
+          },
+          "geodetic_wgs84": {
+            "longitude_deg": 1,
+            "latitude_deg": 1,
+            "height_wgs84_m": 0
+          }
+        }]
+      }
+    }],
+    "directionality": "DIRECTIONALITY_BIDIRECTIONAL"
+  },
+  "service_attributes_filters": {
+    "bidirectional_service_attributes_filter": {
+      "bandwidth_bps_minimum": 1000000,
+      "one_way_latency_maximum": "1s"
+    }
+  },
+  "priority": 1
+}' localhost:50052 outernet.federation.v1alpha.Federation/ScheduleService
+```
+
+*See [handler.go](./handler/handler.go) for the implementation of `ScheduleService`.*
+
+### MonitorServices
+
+Monitor existing services by their IDs.
+
+```bash
+grpcurl -plaintext -d '{"add_service_ids": ["service-1", "service-2"]}' localhost:50052 outernet.federation.v1alpha.Federation/MonitorServices
+```
+
+*Implemented in [handler.go](./handler/handler.go).*
+
+### CancelService
+
+Cancel an active service.
+
+```bash
+grpcurl -plaintext -d '{"service_id": "service-1"}' localhost:50052 outernet.federation.v1alpha.Federation/CancelService
+```
+
+*Refer to [handler.go](./handler/handler.go) for the `CancelService` functionality.*
+
+## Project Structure
+
+Understanding the project structure helps in navigating and customizing the Cosmic Connector.
+
+```
+/cosmicconnector/
+├── BUILD.bazel     # Example binary build configuration
+├── README.md       # This file
+├── config/         # Configuration package
+│   ├── BUILD.bazel # Build config for config package
+│   ├── config.go
+│   ├── config.proto
+│   └── doc.go
+├── handler/        # Example handler implementation
+│   ├── BUILD.bazel # Build config for handler package
+│   ├── handler.go
+│   └── handler_test.go
+└── main.go         # Example entry point
+```
+
+### Example Components
+
+The example demonstrates:
+1. Configuration loading and validation
+2. Server setup and initialization
+3. Handler implementation for Federation services
+4. Authentication setup (disabled for simplicity)
+5. Observability configuration
+6. Testing implementation with handler_test.go
+
+For implementation details of the core packages used in this example, see the [pkg/go README](../../pkg/go/README.md).

--- a/examples/golang/cosmicconnector/config/BUILD.bazel
+++ b/examples/golang/cosmicconnector/config/BUILD.bazel
@@ -1,0 +1,49 @@
+# Copyright 2024 Outernet Council Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+proto_library(
+    name = "config_proto",
+    srcs = ["config.proto"],
+    deps = [
+        "@protobuf//:empty_proto",
+    ],
+)
+
+go_proto_library(
+    name = "config_go_proto",
+    importpath = "github.com/outernetcouncil/federation/gen/go/examples/golang/cosmicconnector/config",
+    proto = ":config_proto",
+)
+
+go_library(
+    name = "config",
+    srcs = [
+        "config.go",
+        "doc.go",
+    ],
+    importpath = "github.com/outernetcouncil/federation/examples/golang/cosmicconnector/config",
+    deps = [
+        ":config_go_proto",
+        "@com_github_rs_zerolog//:zerolog",
+        "@org_golang_google_protobuf//encoding/prototext",
+    ],
+)

--- a/examples/golang/cosmicconnector/config/config.go
+++ b/examples/golang/cosmicconnector/config/config.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Outernet Council Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config provides utilities related to configuration reading
+// and enactment.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	configpb "github.com/outernetcouncil/federation/gen/go/examples/golang/cosmicconnector/config"
+)
+
+func ReadParams(confPath string) (*configpb.ConnectorParams, error) {
+	if confPath == "" {
+		return nil, errors.New("no config (--config) provided")
+	}
+
+	confData, err := os.ReadFile(confPath)
+	if err != nil {
+		return nil, err
+	} else if len(confData) == 0 {
+		return nil, errors.New("empty config (--config) provided")
+	}
+
+	conf := &configpb.ConnectorParams{}
+	if err = prototext.Unmarshal(confData, conf); err != nil {
+		return nil, fmt.Errorf("unmarshalling config proto: %w", err)
+	}
+
+	return conf, err
+}
+
+// logLevelFlag is a flag.Value implementation for the zerolog.Level type.
+type LogLevelFlag zerolog.Level
+
+func (l *LogLevelFlag) String() string {
+	return fmt.Sprintf("%q", zerolog.Level(*l).String())
+}
+
+func (l *LogLevelFlag) Set(value string) error {
+	level, err := zerolog.ParseLevel(value)
+	if err != nil {
+		return err
+	}
+
+	*l = LogLevelFlag(level)
+	return nil
+}

--- a/examples/golang/cosmicconnector/config/config.proto
+++ b/examples/golang/cosmicconnector/config/config.proto
@@ -1,0 +1,80 @@
+// Copyright 2024 Outernet Council Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Structured configuration for the reference SBI agent binary.
+
+syntax = "proto3";
+
+package outernet.federation.v1alpha.cosmicconnector;
+
+import "google/protobuf/empty.proto";
+
+option go_package = "github.com/outernetcouncil/federation/gen/go/examples/golang/cosmicconnector/config;configpb";
+
+// A strategy for signing a JWT.
+message SigningStrategy {
+  oneof type {
+    // The bytes of a PEM-encoded RSA private key in PKCS #1, ASN.1 DER form or
+    // in (unencrypted) PKCS #8, ASN.1 DER form.
+    bytes private_key_bytes = 1;
+    // The path to a PEM-encoded RSA private key in PKCS #1, ASN.1 DER form or
+    // in (unencrypted) PKCS #8, ASN.1 DER form.
+    string private_key_file = 2;
+  }
+}
+
+// For details on Spacetime Auth, see https://docs.spacetime.aalyria.com/authentication.
+message AuthStrategy {
+  // Jwt is a JSON web token. See https://jwt.io/introduction for more
+  // information.
+  message Jwt {
+    string email = 1;
+    string audience = 2;
+    string private_key_id = 3;
+    SigningStrategy signing_strategy = 4;
+  }
+
+  oneof type {
+    // The specifications for a JWT that should be generated and signed by the
+    // agent.
+    Jwt jwt = 1;
+
+    // No authentication options should be used. This is unlikely to work for
+    // you.
+    google.protobuf.Empty none = 2;
+  }
+}
+
+message ObservabilityParams {
+  // Channelz is a gRPC introspection service that can aid in debugging and
+  // understanding gRPC behavior. See
+  // https://grpc.io/blog/a-short-introduction-to-channelz/ and
+  // https://github.com/grpc/proposal/blob/master/A14-channelz.md for more
+  // details.
+  //
+  // The address to start the channelz server on. If blank, the channelz
+  // server will not be started.
+  string channelz_address = 2;
+
+  // The address to start Go's standard net/http/pprof server on. If blank, the
+  // pprof server will not be started.
+  string pprof_address = 3;
+}
+
+message ConnectorParams {
+  // The port on which to offer the Federation gRPC service.
+  uint32 port = 1;
+
+  ObservabilityParams observability_params = 2;
+}

--- a/examples/golang/cosmicconnector/config/doc.go
+++ b/examples/golang/cosmicconnector/config/doc.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Outernet Council Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package config provides configuration management utilities for the Cosmic Connector service.
+It handles reading, parsing, and validating configuration parameters from protobuf-based
+configuration files.
+
+# Configuration Components
+
+The package supports the following configuration aspects:
+
+  - Server configuration (port, TLS settings)
+  - Observability parameters (metrics, tracing, debugging)
+  - Logging configuration
+
+# Core Types
+
+  - ConnectorParams: Primary configuration container
+  - ObservabilityParams: Monitoring and debugging settings
+  - LogLevelFlag: Custom flag.Value implementation for zerolog levels
+
+# Usage Examples
+
+Basic configuration reading:
+
+	params, err := config.ReadParams(configPath)
+	if err != nil {
+	    log.Fatal(err)
+	}
+
+Configuration validation:
+
+	if err := params.Validate(); err != nil {
+	    log.Fatal("Invalid configuration:", err)
+	}
+
+# Configuration Format
+
+Configuration files use Protocol Buffer text format. Example:
+
+	port: 50052
+	observability_params {
+	    channelz_address: "0.0.0.0:50051"
+	    pprof_address: "0.0.0.0:6060"
+	}
+
+# Integration Points
+
+The package integrates with:
+
+  - zerolog for logging
+  - protobuf for configuration format
+  - flag package for command-line parsing
+
+# Monitoring and Debugging
+
+The package supports:
+
+  - Channelz for gRPC monitoring
+  - pprof for performance profiling
+  - Custom metric endpoints
+
+For detailed technical specifications, refer to the config.proto file.
+*/
+package config

--- a/examples/golang/cosmicconnector/handler/BUILD.bazel
+++ b/examples/golang/cosmicconnector/handler/BUILD.bazel
@@ -1,0 +1,48 @@
+# Copyright 2024 Outernet Council Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+package(
+    default_visibility = ["//examples/golang/cosmicconnector:__subpackages__"],
+)
+
+go_library(
+    name = "handler",
+    srcs = ["handler.go"],
+    importpath = "github.com/outernetcouncil/federation/examples/golang/cosmicconnector/handler",
+    deps = [
+        "//outernet/federation/v1alpha:federation_go_grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_outernetcouncil_nmts//proto/types/ietf:ietf_go_proto",
+    ],
+)
+
+go_test(
+    name = "handler_test",
+    size = "small",
+    srcs = ["handler_test.go"],
+    embed = [":handler"],
+    deps = [
+        "//outernet/federation/v1alpha:federation_go_grpc",
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_google_go_cmp//cmp/cmpopts",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//testing/protocmp",
+        "@org_outernetcouncil_nmts//proto/types/ietf:ietf_go_proto",
+    ],
+)

--- a/examples/golang/cosmicconnector/handler/handler.go
+++ b/examples/golang/cosmicconnector/handler/handler.go
@@ -1,0 +1,156 @@
+// Copyright 2024 Outernet Council Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package handler
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/outernetcouncil/federation/gen/go/federation/v1alpha"
+	inet "outernetcouncil.org/nmts/proto/types/ietf"
+)
+
+type PrototypeHandler struct {
+	pb.UnimplementedFederationServer
+	mu               sync.Mutex
+	services         map[string]*pb.ServiceStatus
+	interconnections map[string]*pb.InterconnectionPoint
+}
+
+func NewPrototypeHandler() *PrototypeHandler {
+	return &PrototypeHandler{
+		services:         make(map[string]*pb.ServiceStatus),
+		interconnections: make(map[string]*pb.InterconnectionPoint),
+	}
+}
+
+func (h *PrototypeHandler) StreamInterconnectionPoints(req *pb.StreamInterconnectionPointsRequest, stream pb.Federation_StreamInterconnectionPointsServer) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	chunk := &pb.StreamInterconnectionPointsResponseChunk{
+		SnapshotComplete: &pb.StreamInterconnectionPointsResponseChunk_SnapshotComplete{},
+	}
+
+	for _, ip := range h.interconnections {
+		chunk.Mutations = append(chunk.Mutations, &pb.InterconnectionMutation{
+			Type: &pb.InterconnectionMutation_Upsert{
+				Upsert: ip,
+			},
+		})
+	}
+
+	if err := stream.Send(chunk); err != nil {
+		return err
+	}
+
+	if req.SnapshotOnly != nil && *req.SnapshotOnly {
+		return nil
+	}
+
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (h *PrototypeHandler) ListServiceOptions(req *pb.ListServiceOptionsRequest, stream pb.Federation_ListServiceOptionsServer) error {
+	ipNetwork := &inet.IPNetwork{
+		Prefix: &inet.IPPrefix{
+			Version: &inet.IPPrefix_Ipv4{
+				Ipv4: &inet.IPv4Prefix{
+					Str: "192.168.1.0/24",
+				},
+			},
+		},
+		// Optionally set realm if needed
+		Realm: "",
+	}
+
+	response := &pb.ListServiceOptionsResponse{
+		ServiceOptions: []*pb.ServiceOption{
+			{
+				Id: "sample-service-option",
+				EndpointX: &pb.ServiceOption_XProviderInterconnection{
+					XProviderInterconnection: &pb.InterconnectionPoint{
+						Uuid: "sample-provider-interconnection",
+					},
+				},
+				EndpointY: &pb.ServiceOption_IpNetwork{
+					IpNetwork: ipNetwork,
+				},
+				Directionality: pb.Directionality_DIRECTIONALITY_BIDIRECTIONAL,
+			},
+		},
+	}
+
+	return stream.Send(response)
+}
+
+func (h *PrototypeHandler) ScheduleService(ctx context.Context, req *pb.ScheduleServiceRequest) (*pb.ScheduleServiceResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	serviceID := fmt.Sprintf("service-%d", len(h.services)+1)
+	h.services[serviceID] = &pb.ServiceStatus{
+		Id: serviceID,
+		Type: &pb.ServiceStatus_ServiceUpdate_{
+			ServiceUpdate: &pb.ServiceStatus_ServiceUpdate{
+				IsActive: true,
+			},
+		},
+	}
+
+	return &pb.ScheduleServiceResponse{
+		ServiceId: serviceID,
+	}, nil
+}
+
+func (h *PrototypeHandler) MonitorServices(stream pb.Federation_MonitorServicesServer) error {
+	for {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		h.mu.Lock()
+		for _, serviceID := range req.AddServiceIds {
+			if status, exists := h.services[serviceID]; exists {
+				if err := stream.Send(&pb.MonitorServicesResponse{
+					UpdatedServices: []*pb.ServiceStatus{status},
+				}); err != nil {
+					h.mu.Unlock()
+					return err
+				}
+			}
+		}
+		h.mu.Unlock()
+	}
+}
+
+func (h *PrototypeHandler) CancelService(ctx context.Context, req *pb.CancelServiceRequest) (*pb.CancelServiceResponse, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, exists := h.services[req.ServiceId]; !exists {
+		return nil, status.Errorf(codes.NotFound, "service %s not found", req.ServiceId)
+	}
+
+	delete(h.services, req.ServiceId)
+	return &pb.CancelServiceResponse{
+		Cancelled: true,
+	}, nil
+}

--- a/examples/golang/cosmicconnector/handler/handler_test.go
+++ b/examples/golang/cosmicconnector/handler/handler_test.go
@@ -1,0 +1,490 @@
+// Copyright 2024 Outernet Council Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package handler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	pb "github.com/outernetcouncil/federation/gen/go/federation/v1alpha"
+	inet "outernetcouncil.org/nmts/proto/types/ietf"
+)
+
+func TestPrototypeHandler_ScheduleService(t *testing.T) {
+	h := NewPrototypeHandler()
+	ctx := context.Background()
+
+	req := &pb.ScheduleServiceRequest{
+		Type: &pb.ScheduleServiceRequest_RequestorEdgeToIpNetwork{
+			RequestorEdgeToIpNetwork: &pb.RequestorEdgeToIpNetwork{},
+		},
+	}
+
+	resp, err := h.ScheduleService(ctx, req)
+	if err != nil {
+		t.Fatalf("ScheduleService failed: %v", err)
+	}
+
+	if resp.ServiceId == "" {
+		t.Error("Expected non-empty ServiceId")
+	}
+
+	if len(h.services) != 1 {
+		t.Errorf("Expected 1 service, got %d", len(h.services))
+	}
+
+	service, exists := h.services[resp.ServiceId]
+	if !exists {
+		t.Errorf("Service %s not found in handler", resp.ServiceId)
+	}
+
+	if service.Id != resp.ServiceId {
+		t.Errorf("Service ID mismatch. Expected %s, got %s", resp.ServiceId, service.Id)
+	}
+
+	if update, ok := service.Type.(*pb.ServiceStatus_ServiceUpdate_); !ok || !update.ServiceUpdate.IsActive {
+		t.Error("Expected service to be active")
+	}
+}
+
+func TestPrototypeHandler_CancelService(t *testing.T) {
+	h := NewPrototypeHandler()
+	ctx := context.Background()
+
+	// Schedule a service first
+	scheduleReq := &pb.ScheduleServiceRequest{
+		Type: &pb.ScheduleServiceRequest_RequestorEdgeToIpNetwork{
+			RequestorEdgeToIpNetwork: &pb.RequestorEdgeToIpNetwork{},
+		},
+	}
+	scheduleResp, _ := h.ScheduleService(ctx, scheduleReq)
+
+	tests := []struct {
+		name        string
+		serviceID   string
+		expectError bool
+		errorCode   codes.Code
+	}{
+		{
+			name:        "Cancel existing service",
+			serviceID:   scheduleResp.ServiceId,
+			expectError: false,
+		},
+		{
+			name:        "Cancel non-existent service",
+			serviceID:   "non-existent-id",
+			expectError: true,
+			errorCode:   codes.NotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &pb.CancelServiceRequest{
+				ServiceId: tt.serviceID,
+			}
+
+			resp, err := h.CancelService(ctx, req)
+
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("Expected an error, but got nil")
+				}
+				if status.Code(err) != tt.errorCode {
+					t.Errorf("Expected error code %v, got %v", tt.errorCode, status.Code(err))
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if !resp.Cancelled {
+					t.Error("Expected Cancelled to be true")
+				}
+				if _, exists := h.services[tt.serviceID]; exists {
+					t.Error("Service still exists after cancellation")
+				}
+			}
+		})
+	}
+}
+
+func TestPrototypeHandler_StreamInterconnectionPoints(t *testing.T) {
+	tests := []struct {
+		name         string
+		snapshotOnly bool
+		points       []*pb.InterconnectionPoint
+		wantErr      bool
+	}{
+		{
+			name:         "Empty snapshot",
+			snapshotOnly: true,
+			points:       []*pb.InterconnectionPoint{},
+		},
+		{
+			name:         "Single point snapshot",
+			snapshotOnly: true,
+			points: []*pb.InterconnectionPoint{
+				{
+					Uuid: "test-point-1",
+				},
+			},
+		},
+		{
+			name:         "Multiple points streaming",
+			snapshotOnly: false,
+			points: []*pb.InterconnectionPoint{
+				{Uuid: "test-point-1"},
+				{Uuid: "test-point-2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewPrototypeHandler()
+
+			// Populate test data
+			h.mu.Lock()
+			for _, p := range tt.points {
+				h.interconnections[p.Uuid] = p
+			}
+			h.mu.Unlock()
+
+			// Create mock stream
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			stream := &mockStreamInterconnectionPointsServer{
+				ctx:      ctx,
+				recvChan: make(chan *pb.StreamInterconnectionPointsRequest, 1),
+				sendChan: make(chan *pb.StreamInterconnectionPointsResponseChunk, 10),
+			}
+
+			// Send initial request
+			req := &pb.StreamInterconnectionPointsRequest{
+				SnapshotOnly: &tt.snapshotOnly,
+			}
+
+			// Run stream in goroutine
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- h.StreamInterconnectionPoints(req, stream)
+			}()
+
+			// Verify received chunks
+			chunk := <-stream.sendChan
+			if len(chunk.Mutations) != len(tt.points) {
+				t.Errorf("Got %d mutations, want %d", len(chunk.Mutations), len(tt.points))
+			}
+
+			if !tt.snapshotOnly {
+				// Verify streaming continues until context cancelled
+				select {
+				case <-errChan:
+					t.Error("Stream ended prematurely")
+				case <-ctx.Done():
+					// Expected behavior
+				}
+			}
+		})
+	}
+}
+
+// Mock stream implementation
+type mockStreamInterconnectionPointsServer struct {
+	ctx      context.Context
+	recvChan chan *pb.StreamInterconnectionPointsRequest
+	sendChan chan *pb.StreamInterconnectionPointsResponseChunk
+	grpc.ServerStream
+}
+
+func (m *mockStreamInterconnectionPointsServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockStreamInterconnectionPointsServer) Send(chunk *pb.StreamInterconnectionPointsResponseChunk) error {
+	select {
+	case m.sendChan <- chunk:
+		return nil
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	}
+}
+
+func TestPrototypeHandler_ListServiceOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *pb.ListServiceOptionsRequest
+		want []*pb.ServiceOption
+	}{
+		{
+			name: "Basic service options",
+			req:  &pb.ListServiceOptionsRequest{},
+			want: []*pb.ServiceOption{
+				{
+					Id: "sample-service-option",
+					EndpointX: &pb.ServiceOption_XProviderInterconnection{
+						XProviderInterconnection: &pb.InterconnectionPoint{
+							Uuid: "sample-provider-interconnection",
+						},
+					},
+					EndpointY: &pb.ServiceOption_IpNetwork{
+						IpNetwork: &inet.IPNetwork{
+							Prefix: &inet.IPPrefix{
+								Version: &inet.IPPrefix_Ipv4{
+									Ipv4: &inet.IPv4Prefix{
+										Str: "192.168.1.0/24",
+									},
+								},
+							},
+						},
+					},
+					Directionality: pb.Directionality_DIRECTIONALITY_BIDIRECTIONAL,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewPrototypeHandler()
+			stream := &mockListServiceOptionsServer{
+				ctx:       context.Background(),
+				responses: make(chan *pb.ListServiceOptionsResponse, 1),
+			}
+
+			err := h.ListServiceOptions(tt.req, stream)
+			if err != nil {
+				t.Fatalf("ListServiceOptions() error = %v", err)
+			}
+
+			select {
+			case resp := <-stream.responses:
+				// Add proper comparison options for protobuf messages
+				opts := []cmp.Option{
+					cmpopts.IgnoreUnexported(
+						pb.ServiceOption{},
+						pb.InterconnectionPoint{},
+						pb.ServiceOption_XProviderInterconnection{},
+						pb.ServiceOption_IpNetwork{},
+						inet.IPNetwork{},
+						inet.IPPrefix{},
+						inet.IPv4Prefix{},
+					),
+					protocmp.Transform(),
+				}
+				if diff := cmp.Diff(tt.want, resp.ServiceOptions, opts...); diff != "" {
+					t.Errorf("ListServiceOptions() mismatch (-want +got):\n%s", diff)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timeout waiting for response")
+			}
+		})
+	}
+}
+
+type mockListServiceOptionsServer struct {
+	ctx       context.Context
+	responses chan *pb.ListServiceOptionsResponse
+	grpc.ServerStream
+}
+
+func (m *mockListServiceOptionsServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockListServiceOptionsServer) Send(resp *pb.ListServiceOptionsResponse) error {
+	select {
+	case m.responses <- resp:
+		return nil
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	}
+}
+
+func TestPrototypeHandler_MonitorServices(t *testing.T) {
+	tests := []struct {
+		name     string
+		services map[string]*pb.ServiceStatus
+		updates  []*pb.MonitorServicesRequest
+		want     []*pb.ServiceStatus
+	}{
+		{
+			name: "Monitor single service",
+			services: map[string]*pb.ServiceStatus{
+				"service-1": {
+					Id: "service-1",
+					Type: &pb.ServiceStatus_ServiceUpdate_{
+						ServiceUpdate: &pb.ServiceStatus_ServiceUpdate{
+							IsActive: true,
+						},
+					},
+				},
+			},
+			updates: []*pb.MonitorServicesRequest{
+				{AddServiceIds: []string{"service-1"}},
+			},
+			want: []*pb.ServiceStatus{
+				{
+					Id: "service-1",
+					Type: &pb.ServiceStatus_ServiceUpdate_{
+						ServiceUpdate: &pb.ServiceStatus_ServiceUpdate{
+							IsActive: true,
+						},
+					},
+				},
+			},
+		},
+		// Add more test cases
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewPrototypeHandler()
+
+			// Setup initial services
+			h.mu.Lock()
+			h.services = tt.services
+			h.mu.Unlock()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			stream := newMockMonitorServicesServer(ctx, len(tt.updates))
+
+			// Start monitoring in background
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- h.MonitorServices(stream)
+			}()
+
+			// Send updates
+			for _, update := range tt.updates {
+				if err := stream.sendRequest(update, time.Second); err != nil {
+					t.Fatalf("Failed to send request: %v", err)
+				}
+			}
+
+			// Verify responses
+			for i := 0; i < len(tt.want); i++ {
+				resp, err := stream.receiveUpdate(time.Second)
+				if err != nil {
+					t.Fatalf("Failed to receive update: %v", err)
+				}
+
+				if len(resp.UpdatedServices) != 1 {
+					t.Fatalf("Expected 1 updated service, got %d", len(resp.UpdatedServices))
+				}
+
+				if diff := cmp.Diff(tt.want[i], resp.UpdatedServices[0],
+					protocmp.Transform(),
+					cmpopts.IgnoreUnexported(
+						pb.ServiceStatus{},
+						pb.ServiceStatus_ServiceUpdate{},
+						pb.ServiceStatus_ServiceUpdate_{},
+					)); diff != "" {
+					t.Errorf("MonitorServices() mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			// Clean shutdown
+			cancel()
+			if err := <-errChan; err != nil && err != context.Canceled {
+				t.Errorf("MonitorServices() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+type mockMonitorServicesServer struct {
+	ctx      context.Context
+	requests chan *pb.MonitorServicesRequest
+	updates  chan *pb.MonitorServicesResponse
+	grpc.ServerStream
+}
+
+func (m *mockMonitorServicesServer) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockMonitorServicesServer) Send(resp *pb.MonitorServicesResponse) error {
+	select {
+	case m.updates <- resp:
+		return nil
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	}
+}
+
+func (m *mockMonitorServicesServer) Recv() (*pb.MonitorServicesRequest, error) {
+	select {
+	case req := <-m.requests:
+		return req, nil
+	case <-m.ctx.Done():
+		return nil, m.ctx.Err()
+	}
+}
+
+// Helper method to create a new mock server with reasonable defaults
+func newMockMonitorServicesServer(ctx context.Context, bufferSize int) *mockMonitorServicesServer {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if bufferSize <= 0 {
+		bufferSize = 10
+	}
+	return &mockMonitorServicesServer{
+		ctx:      ctx,
+		requests: make(chan *pb.MonitorServicesRequest, bufferSize),
+		updates:  make(chan *pb.MonitorServicesResponse, bufferSize),
+	}
+}
+
+// Helper methods for testing
+func (m *mockMonitorServicesServer) sendRequest(req *pb.MonitorServicesRequest, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	select {
+	case m.requests <- req:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout sending request")
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	}
+}
+
+func (m *mockMonitorServicesServer) receiveUpdate(timeout time.Duration) (*pb.MonitorServicesResponse, error) {
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	select {
+	case update := <-m.updates:
+		return update, nil
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("timeout receiving update")
+	case <-m.ctx.Done():
+		return nil, m.ctx.Err()
+	}
+}

--- a/examples/golang/cosmicconnector/main.go
+++ b/examples/golang/cosmicconnector/main.go
@@ -1,0 +1,126 @@
+// Copyright 2024 Outernet Council Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package main produces an example Cosmic Connector binary, offering a simple and incomplete example of a Federation service.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/outernetcouncil/federation/examples/golang/cosmicconnector/config"
+	examplehandler "github.com/outernetcouncil/federation/examples/golang/cosmicconnector/handler"
+	"github.com/outernetcouncil/federation/pkg/go/cosmicconnector"
+	"github.com/outernetcouncil/federation/pkg/go/server"
+)
+
+const (
+	appName = "cosmic_connector"
+)
+
+func baseContext(ctx context.Context) context.Context {
+	var log zerolog.Logger
+	if os.Getenv("TERM") != "" {
+		log = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: "2006-01-02 03:04:05PM"})
+	} else {
+		log = zerolog.New(os.Stdout)
+	}
+	return log.With().Timestamp().Logger().WithContext(ctx)
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctx = baseContext(ctx)
+	logger := zerolog.Ctx(ctx)
+
+	fs := flag.NewFlagSet(appName, flag.ContinueOnError)
+	confPath := fs.String("config", "", "The path to a text protobuf representation of the connector's configuration (a ConnectorParams message).")
+	dryRunOnly := fs.Bool("dry-run", false, "Just validate the config, don't start the agent. Exits with a non-zero return code if the config is invalid.")
+	logLevel := config.LogLevelFlag(zerolog.InfoLevel)
+	fs.Var(&logLevel, "log-level", "The log level (one of disabled, warn, panic, info, fatal, error, debug, or trace) to use.")
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintf(w, "Usage: %s [options] [query|exec|dump]\n", appName)
+		fmt.Fprint(w, "\nOptions:\n")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(os.Args[1:]); err == flag.ErrHelp {
+		fs.Usage()
+		os.Exit(0)
+	} else if err != nil {
+		logger.Fatal().Err(err).Msg("failed to parse flags")
+	}
+
+	cp, err := config.ReadParams(*confPath)
+	if err != nil {
+		logger.Fatal().Err(err).Msgf("failed config.ReadParams(%s)", *confPath)
+	}
+
+	if *dryRunOnly {
+		logger.Info().Msg("Dry run only, terminating")
+		return
+	}
+
+	// Initialize Servers based on configuration
+	grpcServer := server.NewGrpcServer(int(cp.GetPort()), examplehandler.NewPrototypeHandler(), *logger)
+	pprofServer := server.NewPprofServer(cp.GetObservabilityParams().GetPprofAddress(), *logger)
+	channelzServer := server.NewChannelzServer(cp.GetObservabilityParams().GetChannelzAddress(), *logger)
+
+	// Create CosmicConnector with initialized servers
+	connector := cosmicconnector.NewCosmicConnector(*logger, grpcServer, pprofServer, channelzServer)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- connector.Run(ctx)
+	}()
+
+	// Wait for either an error from the connector or an interrupt signal
+	select {
+	case err := <-errChan:
+		if err != nil {
+			logger.Fatal().Err(err).Msg("cosmicconnector.Run(...) failed")
+		}
+	case <-sigChan:
+		logger.Info().Msg("Received interrupt signal. Shutting down...")
+		cancel()
+
+		// Give some time for graceful shutdown
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+
+		select {
+		case <-shutdownCtx.Done():
+			logger.Warn().Msg("Shutdown timed out")
+		case err := <-errChan:
+			if err != nil {
+				logger.Error().Err(err).Msg("Error during shutdown")
+			} else {
+				logger.Info().Msg("Shutdown completed successfully")
+			}
+		}
+	}
+}

--- a/outernet/federation/v1alpha/BUILD.bazel
+++ b/outernet/federation/v1alpha/BUILD.bazel
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@gazelle//:def.bzl", "gazelle")
 load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_buf//buf:defs.bzl", "buf_lint_test")
@@ -22,9 +21,6 @@ buf_lint_test(
     targets = [":federation_proto"],
     config = "buf.yaml",
 )
-
-# gazelle:prefix github.com/outernetcouncil/federation
-gazelle(name = "gazelle")
 
 proto_library(
     name = "federation_proto",
@@ -55,4 +51,3 @@ go_proto_library(
         "@org_outernetcouncil_nmts//proto/types/ietf:ietf_go_proto",
     ],
 )
-


### PR DESCRIPTION
This PR introduces a complete example implementation of a Cosmic Connector, demonstrating Federation gRPC service integration. Key additions include:

- Example Cosmic Connector implementation with configuration management
- Bazel build configuration for the example
- Handler implementation for a basic notional Federation service endpoints
- Handler unit tests with mock servers
- Documentation covering setup, configuration, and usage
- Integration of observability features (channelz, pprof)

Adds go_deps for google/go-cmp in MODULE.bazel for testing support.

The example serves as a reference implementation for Federation service consumers.