### PR TITLE
Remove gazelle_override by downgrading dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -95,8 +95,8 @@ go_deps.module(
 
 go_deps.module(
     path = "github.com/bufbuild/protocompile",
-    sum = "h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=",
-    version = "v0.14.1",
+    sum = "h1:6cwUB0Y2tSvmNxsbunwzmIto3xOlJOV7ALALuVOs92M=",
+    version = "v0.13.0",
 )
 
 go_deps.module(
@@ -175,12 +175,6 @@ go_deps.module(
     path = "github.com/golang/groupcache",
     sum = "h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=",
     version = "v0.0.0-20210331224755-41bb18bfe9da",
-)
-
-go_deps.module(
-    path = "github.com/golang/protobuf",
-    sum = "h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=",
-    version = "v1.5.4",
 )
 
 go_deps.module(
@@ -471,12 +465,6 @@ go_deps.module(
     version = "v0.0.0-20191204190536-9bdfabe68543",
 )
 
-go_deps.gazelle_override(
-    path = "github.com/bufbuild/protocompile",
-    directives = [
-        "gazelle:proto disable"
-    ]
-)
 # ---------------------------
 # End of dependencies for api-lint only
 # ---------------------------


### PR DESCRIPTION
This PR came about because it came to light that Bazel projects depending upon e.g. Federation as a Bazel Module dependency - do not allow for `go_deps.gazelle_override` which is a global override.

The underlying issue is triggered by `bufbuild/protocompile` PR @ https://github.com/bufbuild/protocompile/pull/310 - so for now we roll back to the `bufbuild/protocompile` release prior to PR 310.

In the future, we have to either address this upstream dep issue, or migrate to a prebuilt `bufbuild/protocompile` binary instead of the current Federation build via Bazel.