### PR TITLE
Move Platform specification from SignalChains to Transceiver

### DIFF
--- a/outernet/federation/interconnect/v1alpha/interconnect.proto
+++ b/outernet/federation/interconnect/v1alpha/interconnect.proto
@@ -276,6 +276,9 @@ message Transceiver {
   TransmitSignalChain transmit_signal_chain = 3 [
     (google.api.field_behavior) = REQUIRED
   ];
+  nmts.v1alpha.ek.physical.Platform platform = 4 [
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message ReceiveSignalChain {
@@ -289,10 +292,7 @@ message ReceiveSignalChain {
   nmts.v1alpha.ek.physical.Receiver receiver = 3 [
     (google.api.field_behavior) = REQUIRED
   ];
-  nmts.v1alpha.ek.physical.Platform platform = 4 [
-    (google.api.field_behavior) = REQUIRED
-  ];
-  nmts.v1alpha.ek.physical.Antenna antenna = 5 [
+  nmts.v1alpha.ek.physical.Antenna antenna = 4 [
     (google.api.field_behavior) = REQUIRED
   ];
 }
@@ -308,10 +308,7 @@ message TransmitSignalChain {
   nmts.v1alpha.ek.physical.Transmitter transmitter = 3 [
     (google.api.field_behavior) = REQUIRED
   ];
-  nmts.v1alpha.ek.physical.Platform platform = 4 [
-    (google.api.field_behavior) = REQUIRED
-  ];
-  nmts.v1alpha.ek.physical.Antenna antenna = 5 [
+  nmts.v1alpha.ek.physical.Antenna antenna = 4 [
     (google.api.field_behavior) = REQUIRED
   ];
 }


### PR DESCRIPTION
This because it did not make sense, in the common case, to have two possibly differing platform specifications for a Transceiver (one for Rx one for Tx SignalChain).

Field identifiers were updated in this PR - which is a breaking change - but deemed acceptable as this proto is not yet in use.